### PR TITLE
增加音乐检测模块

### DIFF
--- a/Assets/Script/AudioAnimation.cs
+++ b/Assets/Script/AudioAnimation.cs
@@ -3,7 +3,6 @@ using CSCore.CoreAudioAPI;
 using CSCore.SoundIn;
 using CSCore.Streams;
 using UnityEngine;
-using VInspector;
 
 public class AudioAnimation : MonoBehaviour
 {
@@ -17,7 +16,7 @@ public class AudioAnimation : MonoBehaviour
     private float[] audioSamples;
     private int offset;
     private int byteCount;
-   
+
     public MiSideStart miside;
     public float nodEnergyThreshold = 0.01f; // 初始阈值
     [SerializeField]
@@ -26,9 +25,9 @@ public class AudioAnimation : MonoBehaviour
     private float previousEnergy;
     [SerializeField]
     private bool nod = false;
-    [SerializeField,ReadOnly]
+    [SerializeField]
     private string audioDeviceName;
-    [SerializeField,ReadOnly]
+    [SerializeField]
     private string audioDeviceID;
 
     private float averageEnergy = 0f;
@@ -36,7 +35,12 @@ public class AudioAnimation : MonoBehaviour
     private float peakDetectionThreshold = 1.5f; // 峰值检测阈值
     private float smoothingFactor = 0.7f; // 平滑滤波因子
 
-    public float nodEnergy; // 添加 nodEnergy 属性
+    private const float zeroCrossingRateThreshold = 0.05f;
+    private const float shortTimeEnergyThreshold = 0.01f;
+
+    // 添加 nodEnergy 属性
+    public float nodEnergy { get; private set; }
+    private bool isMusic = false; // 新增：用于存储音乐检测结果
 
     private void Awake()
     {
@@ -81,7 +85,7 @@ public class AudioAnimation : MonoBehaviour
         }
         if (!MiSideStart.config.MusicHead)
             return;
-        if (nod)
+        if (nod && isMusic) // 确保只在检测为音乐且nod为true时执行
         {
             miside.NodOnShot();
             nod = false;
@@ -101,7 +105,6 @@ public class AudioAnimation : MonoBehaviour
         if (buffer == null || buffer.Length == 0)
             return;
 
-        // 将 buffer 转换为浮点数据
         int sampleCount = byteCount / sizeof(float);
         int startCount = offset / sizeof(float);
         int count = sampleCount - startCount;
@@ -115,23 +118,62 @@ public class AudioAnimation : MonoBehaviour
         }
         energy /= count; // 平均能量
 
+        // 更新 nodEnergy
+        nodEnergy = energy;
+
         // 平滑滤波
         energy = SmoothingFilter(energy);
 
         // 更新平均能量
         averageEnergy = averageEnergy * energyDecayFactor + energy * (1 - energyDecayFactor);
 
-        // 自适应阈值检测
-        float adaptiveThreshold = nodEnergy + nodEnergyThreshold * averageEnergy;
+        // 检查是否为音乐
+        isMusic = CheckIsMusic(audioSamples); // 实时更新音乐检测结果
 
-        // 检测节拍
-        if (energy > adaptiveThreshold && energy > peakDetectionThreshold * averageEnergy)
+        // 自适应阈值检测（仅当是音乐时）
+        if (isMusic)
         {
-            nod = true;
+            float adaptiveThreshold = nodEnergyThreshold + nodEnergyThreshold * averageEnergy;
+
+            // 检测节拍
+            if (energy > adaptiveThreshold && energy > peakDetectionThreshold * averageEnergy)
+            {
+                nod = true;
+            }
         }
 
         previousEnergy = energy;
         currentEnergy = energy;
+    }
+
+    private float CalculateZeroCrossingRate(float[] audioSamples)
+    {
+        int zeroCrossingCount = 0;
+        for (int i = 1; i < audioSamples.Length; i++)
+        {
+            if (audioSamples[i] * audioSamples[i - 1] < 0)
+            {
+                zeroCrossingCount++;
+            }
+        }
+        return (float)zeroCrossingCount / audioSamples.Length;
+    }
+
+    private float CalculateShortTimeEnergy(float[] audioSamples)
+    {
+        float energy = 0;
+        foreach (float sample in audioSamples)
+        {
+            energy += sample * sample;
+        }
+        return energy / audioSamples.Length;
+    }
+
+    private bool CheckIsMusic(float[] audioSamples)
+    {
+        float zeroCrossingRate = CalculateZeroCrossingRate(audioSamples);
+        float shortTimeEnergy = CalculateShortTimeEnergy(audioSamples);
+        return zeroCrossingRate > zeroCrossingRateThreshold && shortTimeEnergy > shortTimeEnergyThreshold;
     }
 
     private float SmoothingFilter(float value)

--- a/Assets/Script/MiSideStart.cs
+++ b/Assets/Script/MiSideStart.cs
@@ -147,7 +147,7 @@ public class MiSideStart : MonoBehaviour,IPointerClickHandler
         #endif
         LoadConfig();
         // Screen.SetResolution(config.Resolution.x, config.Resolution.y, true);
-        audioAnimation.nodEnergy = config.MusicMinEnergy;
+        //audioAnimation.nodEnergy = config.MusicMinEnergy;
         mouseControl.offset = config.LookAtOffsetMultiplier;
         Application.targetFrameRate = targetFrameRate;
         HideControl();


### PR DESCRIPTION
增加简单的音乐检测模块，当识别到音乐时进行节拍检测，如果不是（如人声）则无反应
能在很大程度上改善效果，但考虑到计算资源有限，原理为根据短时过零率和短时能量判断是否为音乐
一般情况下，音乐的短时过零率相对较高，短时能量也相对较大，因此有可能误触：无法完全识别
代码片段由Fuxuan-CN大佬提供：
![image](https://github.com/user-attachments/assets/c60bf24e-1dca-4fe9-9fd5-c1ab69de937a)
